### PR TITLE
Making the project compatible with .NET 4.0 and Visual Studio 2010

### DIFF
--- a/src/Orient/Orient.Client/API/Types/ODocument.cs
+++ b/src/Orient/Orient.Client/API/Types/ODocument.cs
@@ -350,12 +350,16 @@ namespace Orient.Client
                 }
 
                 bool isSerializable = true;
-                OProperty oProperty = propertyInfo.GetCustomAttribute<OProperty>();
+                object[] oProperties = propertyInfo.GetCustomAttributes(typeof(OProperty), true);
 
-                if (oProperty != null)
+                if (oProperties.Any())
                 {
-                    propertyName = oProperty.Alias;
-                    isSerializable = oProperty.Serializable;
+                    OProperty oProperty = oProperties.First() as OProperty;
+                    if (oProperty != null)
+                    {
+                        propertyName = oProperty.Alias;
+                        isSerializable = oProperty.Serializable;
+                    }
                 }
 
                 if (isSerializable)
@@ -408,11 +412,15 @@ namespace Orient.Client
                         continue;
                     }
 
-                    OProperty oProperty = propertyInfo.GetCustomAttribute<OProperty>();
+                    object[] oProperties = propertyInfo.GetCustomAttributes(typeof(OProperty), true);
 
-                    if (oProperty != null)
+                    if (oProperties.Any())
                     {
-                        propertyName = oProperty.Alias;
+                        OProperty oProperty = oProperties.First() as OProperty;
+                        if (oProperty != null)
+                        {
+                            propertyName = oProperty.Alias;
+                        }
                     }
 
                     string fieldPath = path + (path != "" ? "." : "") + propertyName;

--- a/src/Orient/Orient.Client/Orient.Client.csproj
+++ b/src/Orient/Orient.Client/Orient.Client.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orient.Client</RootNamespace>
     <AssemblyName>Orient.Client</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Orient/Orient.Console/App.config
+++ b/src/Orient/Orient.Console/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0"/>
     </startup>
 </configuration>

--- a/src/Orient/Orient.Console/Orient.Console.csproj
+++ b/src/Orient/Orient.Console/Orient.Console.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orient.Console</RootNamespace>
     <AssemblyName>Orient.Console</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/Orient/Orient.Tests/Orient.Tests.csproj
+++ b/src/Orient/Orient.Tests/Orient.Tests.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orient.Tests</RootNamespace>
     <AssemblyName>Orient.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
@@ -16,6 +16,7 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
     <IsCodedUITest>False</IsCodedUITest>
     <TestProjectType>UnitTest</TestProjectType>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
There's a couple lines here that restrict using prior versions of .NET - this should take care of them and allow much better back-compatibility.
